### PR TITLE
Create cross account module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,6 @@
 *.tfstate
 *.tfstate.*
 
-# aws.tf files so that we never publish profile names
-**/aws.tf
-
 # Crash log files
 crash.log
 .gitignore

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ This repo contains various bits to make it easier to bring up Cloudera Data Plat
 
 I've placed 3 modules each in its own directory as they're designed to be include-able from a common main.tf file.  
 We currently have:
-- S3/  - Create the S3 bucket with Default Encryption and the logs folder 
-- VPC/ - Create the VPC structure that is needed for the CCM/Private IPs feature to work
-- IAM/ - Create IAM Policies & Roles as per [CDP documentation](https://docs.cloudera.com/management-console/cloud/environments/topics/mc-idbroker-minimum-setup.html)
+- cross-account-role - Create IAM role for CDP management access
+- S3  - Create the S3 bucket with Default Encryption and the logs folder 
+- VPC - Create the VPC structure that is needed for the CCM/Private IPs feature to work
+- IAM - Create IAM Policies & Roles as per [CDP documentation](https://docs.cloudera.com/management-console/cloud/environments/topics/mc-idbroker-minimum-setup.html)
 
 How to use
 

--- a/examples/cross_account_plus_iam/aws.tf
+++ b/examples/cross_account_plus_iam/aws.tf
@@ -1,0 +1,18 @@
+##   Terraform to set up a VPC for CDP w/ CCM (Private IPs) enabled
+##   dnarain@cloudera.com
+
+## Connect this to your AWS account - either provide a region/profile or
+## alternatively the access_key/secret-key 
+
+variable "aws_profile" {
+}
+
+variable "region" {
+}
+
+provider "aws" {
+  profile = var.aws_profile
+  region  = var.region
+  version = "~> 2.39"
+}
+

--- a/examples/cross_account_plus_iam/main.tf
+++ b/examples/cross_account_plus_iam/main.tf
@@ -4,20 +4,6 @@ module "cross-account-role" {
   PREFIX = var.deployment_name_prefix
 }
 
-module "cdp-vpc" {
-  source = "../../modules/vpc"
-
-  PREFIX = var.deployment_name_prefix
-  VPC_CIDR = var.vpc_cidr
-  AZs = var.vpc_azs
-}
-
-module "cdp-s3" {
-  source = "../../modules/s3"
-
-  DATALAKE_BUCKET = var.bucket_name
-}
-
 module "cdp-iam" {
   source = "../../modules/iam"
 

--- a/examples/cross_account_plus_iam/variables.tf
+++ b/examples/cross_account_plus_iam/variables.tf
@@ -1,0 +1,6 @@
+variable "deployment_name_prefix" {
+  default = "CDP2_"
+}
+
+variable "bucket_name" {
+}

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -28,3 +28,21 @@ module "cdp-iam" {
 output "cdp-cross-account-role" {
   value = module.cross-account-role.arn
 }
+
+output "Logs-Select-an-Instance-Profile" {
+  value = "TBD"
+}
+output "Logs-Location-Base" {
+  value = "s3a://${var.bucket_name}/logs"
+}
+
+output "Ranger-Audit-Role" {
+  value = "TBD"
+}
+
+output "Data-Access-Select-an-Instance-Profile" {
+  value = "TBD"
+}
+output "Storage-Location-Base" {
+  value = "s3a://${var.bucket_name}"
+}

--- a/modules/cross-account-role/json_for_policies/cross_account_policy.json
+++ b/modules/cross-account-role/json_for_policies/cross_account_policy.json
@@ -1,0 +1,241 @@
+{
+  "Statement": [
+    {
+      "Sid": "CloudFormationFull",
+      "Action": [
+        "cloudformation:*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "DynamoDBFull",
+      "Action": [
+        "dynamodb:*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "LogsFull",
+      "Action": [
+        "logs:CreateLogGroup"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "LogsLimited",
+      "Action": [
+        "logs:CreateLogStream",
+        "logs:DescribeLogStreams",
+        "logs:PutLogEvents"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:logs:*:*:log-group:/aws/eks/*:*"
+      ]
+    },
+    {
+      "Sid": "EnterpriseKubernetesServiceFull",
+      "Action": [
+        "eks:*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "PerformanceInsightsLimited",
+      "Action": [
+        "pi:*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:pi:*:*:metrics/rds/*"
+      ]
+    },
+    {
+      "Sid": "ElasticLoadBalancingFull",
+      "Action": [
+        "elasticloadbalancing:*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "RelationalDatabaseServiceFull",
+      "Action": [
+        "rds:*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "DomainNameServicesFull",
+      "Action": [
+        "route53:AssociateVPCWithHostedZone",
+        "route53:ChangeResourceRecordSets",
+        "route53:CreateHostedZone",
+        "route53:GetChange",
+        "route53:ListHostedZones",
+        "route53:ListHostedZonesByName",
+        "route53:ListResourceRecordSets"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "CertificateManagerFull",
+      "Action": [
+        "acm:AddTagsToCertificate",
+        "acm:DeleteCertificate",
+        "acm:DescribeCertificate",
+        "acm:GetCertificate",
+        "acm:ListCertificates",
+        "acm:RenewCertificate",
+        "acm:RequestCertificate"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "SimpleStorageServiceFull",
+      "Action": [
+        "s3:AbortMultipartUpload",
+        "s3:CreateBucket",
+        "s3:DeleteObject",
+        "s3:GetObject",
+        "s3:HeadBucket",
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+        "s3:PutObject",
+        "s3:DeleteBucket",
+        "s3:PutBucketPublicAccessBlock"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "ElasticFileSystemFull",
+      "Action": [
+        "elasticfilesystem:*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "ElasticComputeCloudFull",
+      "Action": [
+        "ec2:*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "ElasticComputeCloudLimited",
+      "Action": [
+        "ec2:DeleteTags"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:ec2:*:*:subnet/*",
+        "arn:aws:ec2:*:*:vpc/*"
+      ]
+    },
+    {
+      "Sid": "IdentityAccessManagementFull",
+      "Action": [
+        "iam:AttachRolePolicy",
+        "iam:CreateInstanceProfile",
+        "iam:CreateRole",
+        "iam:DeleteInstanceProfile",
+        "iam:DeleteRole",
+        "iam:ListRolePolicies",
+        "iam:GetInstanceProfile",
+        "iam:GetRolePolicy",
+        "iam:ListAttachedRolePolicies",
+        "iam:ListInstanceProfiles",
+        "iam:PutRolePolicy",
+        "iam:PassRole",
+        "iam:GetRole",
+        "iam:AddRoleToInstanceProfile",
+        "iam:RemoveRoleFromInstanceProfile",
+        "iam:DetachRolePolicy",
+        "iam:DeleteRolePolicy",
+        "iam:SimulatePrincipalPolicy",
+        "iam:ListRoles"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "IdentityAccessManagementLimited",
+      "Action": [
+        "iam:CreateServiceLinkedRole"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:iam::*:role/aws-service-role/*"
+      ]
+    },
+    {
+      "Sid": "AutoScalingFull",
+      "Action": [
+        "autoscaling:*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "KeyManagementServiceFull",
+      "Action": [
+        "kms:CreateAlias",
+        "kms:CreateGrant",
+        "kms:CreateKey",
+        "kms:Decrypt",
+        "kms:EnableKeyRotation",
+        "kms:GenerateRandom",
+        "kms:ListKeys",
+        "kms:ListKeyPolicies",
+        "kms:DescribeKey",
+        "kms:ListAliases",
+        "kms:Encrypt",
+        "kms:TagResource",
+        "kms:DeleteAlias",
+        "kms:PutKeyPolicy",
+        "kms:ScheduleKeyDeletion"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/modules/cross-account-role/json_for_policies/cross_account_role.json
+++ b/modules/cross-account-role/json_for_policies/cross_account_role.json
@@ -1,0 +1,14 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          "arn:aws:iam::387553343826:root"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/modules/cross-account-role/main.tf
+++ b/modules/cross-account-role/main.tf
@@ -1,0 +1,26 @@
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_policy" "cdp-cross-account-policy" {
+  name = "${var.PREFIX}cdp-cross-account-policy"
+  path = "/"
+  description = "Policy required for CDP provisioning"
+
+  policy = file("${path.module}/json_for_policies/cross_account_policy.json")
+}
+
+
+resource "aws_iam_role" "cdp-cross-account-role" {
+  name = "${var.PREFIX}cdp-cross-account-role"
+  description = "CDP management role"
+  assume_role_policy = file("${path.module}/json_for_policies/cross_account_role.json")
+}
+
+resource "aws_iam_role_policy_attachment" "cdp" {
+  role = aws_iam_role.cdp-cross-account-role.name
+  policy_arn = aws_iam_policy.cdp-cross-account-policy.arn
+}
+
+output "arn" {
+  value = aws_iam_role.cdp-cross-account-role.arn
+}

--- a/modules/cross-account-role/variables.tf
+++ b/modules/cross-account-role/variables.tf
@@ -1,0 +1,3 @@
+variable "PREFIX" {
+}
+

--- a/modules/cross-account-role/versions.tf
+++ b/modules/cross-account-role/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/modules/vpc/vpc.tf
+++ b/modules/vpc/vpc.tf
@@ -91,7 +91,7 @@ resource "aws_internet_gateway" "the_igw" {
 
 ## Create a public subnets and have them route to the IGW. 
 resource "aws_subnet" "public_subnets" {
-  count = 3
+  count = length(var.AZs)
   vpc_id = aws_vpc.the_vpc.id
   cidr_block = cidrsubnet(aws_vpc.the_vpc.cidr_block, var.SUBNET_CIDR_NEWBITS, count.index)
   availability_zone = var.AZs[count.index]
@@ -102,13 +102,13 @@ resource "aws_subnet" "public_subnets" {
 }
   
  resource "aws_route_table_association" "public_rt_associations" {
-   count = 3
+   count = length(var.AZs)
    subnet_id = aws_subnet.public_subnets[count.index].id
    route_table_id = aws_route_table.the_public_route.id
  }
 
 resource "aws_eip" "elastic_ips" {
-  count = 3
+  count = length(var.AZs)
   vpc = true
   tags = {
     Name = "${var.PREFIX}cdp-eip-${count.index}"
@@ -116,7 +116,7 @@ resource "aws_eip" "elastic_ips" {
 }
 
 resource "aws_nat_gateway" "nat_gws" {
-  count = 3
+  count = length(var.AZs)
   allocation_id = aws_eip.elastic_ips[count.index].id
   subnet_id = aws_subnet.public_subnets[count.index].id
    tags = {
@@ -126,7 +126,7 @@ resource "aws_nat_gateway" "nat_gws" {
 
 
 resource "aws_subnet" "private_subnets" {
-  count = 3
+  count = length(var.AZs)
   vpc_id = aws_vpc.the_vpc.id
   cidr_block = cidrsubnet(aws_vpc.the_vpc.cidr_block, var.SUBNET_CIDR_NEWBITS, count.index+3)
   availability_zone = var.AZs[count.index]
@@ -136,7 +136,7 @@ resource "aws_subnet" "private_subnets" {
 }
 
 resource "aws_route_table" "private_routes" {
-    count = 3
+    count = length(var.AZs)
     vpc_id = aws_vpc.the_vpc.id
     route {
         cidr_block = "0.0.0.0/0"
@@ -148,7 +148,7 @@ resource "aws_route_table" "private_routes" {
 }
 
 resource "aws_route_table_association" "private_rt_associations" {
-    count = 3
+    count = length(var.AZs)
     subnet_id = aws_subnet.private_subnets[count.index].id
     route_table_id = aws_route_table.private_routes[count.index].id
 }


### PR DESCRIPTION
- Create cross-account-module use for CDP management access in customer environment
- minor tweak in the VPC module to make number of subnet created correlated with the number of regions defined 